### PR TITLE
Update kernel32.def to include missing GetConsoleWindow

### DIFF
--- a/win32/lib/kernel32.def
+++ b/win32/lib/kernel32.def
@@ -229,6 +229,7 @@ GetConsoleOutputCP
 GetConsoleScreenBufferInfo
 GetConsoleTitleA
 GetConsoleTitleW
+GetConsoleWindow
 GetCurrencyFormatA
 GetCurrencyFormatW
 GetCurrentDirectoryA


### PR DESCRIPTION
per https://stackoverflow.com/a/30243650/6104460 
this solved my compile issue
tcc: error: undefined symbol 'GetConsoleWindow'

(I don't know what I'm doing with this git stuff)